### PR TITLE
Minor patch for building on Tiger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+IOSCSITape is a Unix-like tape driver kernel extension (kext) for Mac OS X that enables standard utilities like `tar` and `dd` to work with SCSI tape drives. It includes:
+- A kernel extension (IOSCSITape.kext) that provides character device files (/dev/rst0, etc.)
+- A command-line tool (`mt`) for tape drive manipulation
+
+## Build Configuration for Mac OS X 10.4 Tiger (Xcode 2.5)
+
+The project has been configured to build on Mac OS X 10.4.11 (Tiger) with Xcode 2.5. Key settings:
+- objectVersion = 42 (Xcode 2.5 compatible)
+- SDK: /Developer/SDKs/MacOSX10.4u.sdk
+- Minimum OS Version: MAC_OS_X_VERSION_MIN_REQUIRED = 1040
+- Architectures: ppc and i386 (Universal Binary)
+
+## Build Commands
+
+### Using Xcode 2.5 GUI
+1. Open IOSCSITape.xcodeproj in Xcode 2.5
+2. Select Build Configuration (Debug or Release)
+3. Build All (Cmd+B)
+
+### Using xcodebuild command line
+```bash
+# Build both targets (kext and mt tool)
+xcodebuild -configuration Release
+
+# Build specific target
+xcodebuild -target IOSCSITape -configuration Release
+xcodebuild -target mt -configuration Release
+
+# Clean build
+xcodebuild clean
+```
+
+## Architecture
+
+### Kernel Extension (IOSCSITape.kext)
+- **IOSCSITape.cpp/h**: Main driver class inheriting from IOSCSIPrimaryCommandsDevice
+- Implements SCSI Stream Commands (SSC) for tape operations
+- Provides BSD character device interface through cdevsw callbacks
+
+### mt Tool
+- **mt.c**: Command-line utility for tape operations (rewind, forward space, etc.)
+- **custom_mtio.h**: Additional ioctl definitions for tape operations
+- **mtio.h**: Standard magnetic tape I/O definitions (from 10.5 SDK)
+
+### Key Components
+- Character device operations: st_open, st_close, st_readwrite, st_ioctl
+- SCSI command implementation for tape-specific operations (REWIND, SPACE, WRITE_FILEMARKS, etc.)
+- BSD-IOKit data exchange through IOMemoryDescriptor
+
+## Testing
+
+After building:
+1. Load the kext: `sudo kextload build/Release/IOSCSITape.kext`
+2. Check for device files: `ls -la /dev/rst*`
+3. Use mt tool: `./build/Release/mt -f /dev/rst0 status`
+
+## Important Notes
+
+- This driver is experimental and not intended for production use
+- Requires SCSI tape hardware and appropriate SCSI adapter
+- Must be loaded with appropriate permissions (typically requires sudo)
+- Device files are created automatically when tape drives are detected

--- a/IOSCSITape.cpp
+++ b/IOSCSITape.cpp
@@ -7,7 +7,24 @@
  *
  */
 
-#include <AssertMacros.h>
+/* Include necessary type definitions first */
+#include <sys/types.h>
+#include <sys/systm.h>
+
+/* AssertMacros.h not available in 10.4 SDK, define needed macros */
+#ifndef require
+#define require(assertion, exceptionLabel)  \
+    do {                                     \
+        if (!(assertion)) {                 \
+            goto exceptionLabel;            \
+        }                                    \
+    } while(0)
+#endif
+
+#ifndef ErrorExit
+#define ErrorExit ErrorExit
+#endif
+
 #include <sys/conf.h>
 #include <miscfs/devfs/devfs.h>
 #include <sys/errno.h>

--- a/IOSCSITape.xcodeproj/project.pbxproj
+++ b/IOSCSITape.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 42;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -141,15 +141,8 @@
 		089C1669FE841209C02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			buildConfigurationList = 1DEB91DD08733DB10010E9CD /* Build configuration list for PBXProject "IOSCSITape" */;
-			compatibilityVersion = "Xcode 3.1";
-			developmentRegion = English;
+			compatibilityVersion = "Xcode 2.4";
 			hasScannedForEncodings = 1;
-			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
-			);
 			mainGroup = 089C166AFE841209C02AAC07 /* IOSCSITape */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -251,26 +244,27 @@
 		1DEB91DE08733DB10010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(NATIVE_ARCH)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				MAC_OS_X_VERSION_MIN_REQUIRED = 1040;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Debug;
 		};
 		1DEB91DF08733DB10010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "ppc i386";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MAC_OS_X_VERSION_MIN_REQUIRED = 1040;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Release;
 		};
@@ -281,6 +275,8 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
+				MAC_OS_X_VERSION_MIN_REQUIRED = 1040;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
@@ -296,6 +292,8 @@
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+				MAC_OS_X_VERSION_MIN_REQUIRED = 1040;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 				GCC_MODEL_TUNING = G5;
 				INSTALL_PATH = /usr/local/bin;
 				PREBINDING = NO;

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Discussion can be held on the Google Group mailing list: [ioscsitape-discuss](ht
 **BE ADVISED:** IOSCSITape is not yet intended for production use. It has had limited testing on a very limited set of hardware and is still in early development. Use at your own risk.
 
 _*Can you part with modern tape drives*, autoloaders/libraries, OS X SCSI adapters, or other related equipment? The IOSCSITape project could use donations of equipment to improve and better support a range of devices. Please get in touch with jesse.c.peterson-att-gmail if so. Please: only modern equipment and serious offers._
+
+NOTE: experimental Tiger support added - so far so good on Sony DDS2 drive
+

--- a/mtio.h
+++ b/mtio.h
@@ -67,6 +67,17 @@
 #include <sys/appleapiopts.h>
 #include <sys/cdefs.h>
 
+/* Ensure we have necessary types for Tiger */
+#include <sys/types.h>
+
+#ifndef daddr_t
+typedef int32_t daddr_t;
+#endif
+
+#ifndef u_short
+typedef unsigned short u_short;
+#endif
+
 #ifdef	__APPLE_API_OBSOLETE
 
 /*


### PR DESCRIPTION
 - This patch is specifically for XCode 2.5 on Mac OS X 10.4.11 using the latest 10.4 universal SDK